### PR TITLE
Wider max formant range

### DIFF
--- a/src/new_fave/measurements/vowel_measurement.py
+++ b/src/new_fave/measurements/vowel_measurement.py
@@ -311,6 +311,18 @@ class VowelMeasurement(Sequence):
         return log_prob
 
     @property
+    def max_formant_ecdf_log_prob(self):
+        ecdf = self.vowel_class.vowel_system.max_formant_ecdf
+        prob = ecdf.cdf.evaluate(self.cand_max_formants[0])
+        
+        half_prob = np.array([1-p if p > 0.5 else p for p in prob])/0.5
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            log_prob = np.log(half_prob)
+
+        return log_prob
+    
+    @property
     def error_log_prob(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -839,7 +851,7 @@ class VowelClassCollection(defaultdict):
     def maximum_formant_means(self):
         if self._maximum_formant_means is not None:
             return self._maximum_formant_means
-        self._maximum_formant_means = self.winners_maximum_formant.mean()
+        self._maximum_formant_means = np.median(self.winners_maximum_formant)
         return self.winners_maximum_formant.mean()
     
     @property
@@ -861,6 +873,11 @@ class VowelClassCollection(defaultdict):
         except:
             self._max_formant_icov = np.array([[np.nan]])
             return np.array([[np.nan]])    
+        
+    @property
+    def max_formant_ecdf(self):
+        dist = stats.ecdf(self.winners_maximum_formant[0])
+        return dist
                 
     def to_tracks_df(self):
         """Return a DataFrame of the formant tracks

--- a/src/new_fave/optimize/optimize.py
+++ b/src/new_fave/optimize/optimize.py
@@ -106,7 +106,7 @@ def optimize_one_measure(
         prob_dict["vclass_mahal"] = vowel_measurement.cand_vclass_mahal_log_prob
 
     if "max_formant" in optim_params:
-        prob_dict["max_formant"] = vowel_measurement.max_formant_log_prob
+        prob_dict["max_formant"] = vowel_measurement.max_formant_ecdf_log_prob
         
     joint_prob = vowel_measurement.error_log_prob 
     for dim in optim_params:

--- a/src/new_fave/resources/fasttrack_config.yml
+++ b/src/new_fave/resources/fasttrack_config.yml
@@ -4,10 +4,10 @@ entry_classes:
 target_tier: "Phone"
 target_labels: "[AEIOU]"
 min_duration: 0.05
-min_max_formant: 4800
+min_max_formant: 4000
 max_max_formant: 9000
 n_formants: 3
-nstep: 40
+nstep: 30
 window_length: 0.025
 time_step: 0.002
 time_step: 0.002


### PR DESCRIPTION
speakers at each end of the max-formant range were having fairly poor results. The approach here widens the max formant range, and moves to using distance from the median (rather than mean) for the max-formant log-probability.