### PR TITLE
bugfixes and dataframe pipeline speedups

### DIFF
--- a/docs/usage/python_usage.qmd
+++ b/docs/usage/python_usage.qmd
@@ -25,7 +25,7 @@ from new_fave import fave_audio_textgrid, write_data
 
 speakers = fave_audio_textgrid(
     audio_path = "speaker1.wav",
-    textgrid_path = "speaker2.TextGrid",
+    textgrid_path = "speaker1.TextGrid",
     ## all optional args below
     speakers = "all",
     recode_rules = "cmu2labov",

--- a/src/new_fave/extract.py
+++ b/src/new_fave/extract.py
@@ -106,7 +106,7 @@ configs = cloup.option_group(
         show_default=True,
         help = (
             "A vowel place definition file. "
-            "Values can be the name of a built in config ('defailt) "
+            "Values can be the name of a built in config ('default') "
             "or a path to a custom config file."
         )
     ), 
@@ -433,8 +433,7 @@ def corpus(
         result_which.append(new_which)
     
     audio_to_process = [a for a,w in zip(all_audio, result_which) if len(w) > 0]
-
-    result_which,audio_to_process =  filter_nones(result_which, [result_which, audio_to_process])
+    result_which = [w for w in result_which if len(w) > 0]
 
     corpus = get_corpus(audio_to_process)
 
@@ -541,10 +540,9 @@ def subcorpora(
         result_which.append(new_which)
     
     audio_to_process = [a for a,w in zip(all_audio, result_which) if len(w) > 0]
+    result_which = [w for w in result_which if len(w) > 0]
 
-    result_which,audio_to_process =  filter_nones(result_which, [result_which, audio_to_process])
-
-    corpus = get_corpus(audio_to_process)    
+    corpus = get_corpus(audio_to_process)
 
     include_overlaps = not exclude_overlaps
     if type(speakers) is int:

--- a/src/new_fave/measurements/calcs.py
+++ b/src/new_fave/measurements/calcs.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.typing as npt
 from typing import Any
-import scipy.stats as stats
+from scipy.special import chdtr, chdtrc, chdtri
 import warnings
 import functools
 
@@ -61,10 +61,13 @@ def mahal_log_prob(
             The log probability
     """
     df = np.prod(params.shape[0:-1])
-    log_prob = stats.chi2.logsf(
-            mahals,
-            df = df
-        )
+    median = chdtri(df, 0.5)
+    x = np.clip(mahals, 0.0, None)
+    high = x > median
+    log_prob = np.empty_like(x, dtype=float)
+    with np.errstate(divide="ignore"):
+        log_prob[high] = np.log(chdtrc(df, x[high]))
+        log_prob[~high] = np.log1p(-chdtr(df, x[~high]))
     if np.isfinite(log_prob).mean() < 0.5:
         log_prob = np.zeros(shape = log_prob.shape)    
     return log_prob

--- a/src/new_fave/measurements/calcs.py
+++ b/src/new_fave/measurements/calcs.py
@@ -125,21 +125,21 @@ def cov_to_icov(
     
     return params_icov
 
+@functools.lru_cache(maxsize=None)
+def _cached_property_names(cls: type) -> tuple:
+    return tuple(
+        k for c in cls.__mro__ for k, v in vars(c).items()
+        if isinstance(v, functools.cached_property)
+    )
+
+
 def clear_cached_properties(obj:object) -> None:
     """Clear the cache of any property in an object
 
     Args:
         obj (object): Any object.
     """
-    clses = obj.__class__.mro()
-    to_clear = []
-
-    to_clear += [
-        k 
-        for cls in clses
-        for k, v in vars(cls).items()
-        if isinstance(v, functools.cached_property)
-    ]
-    for var in to_clear:
-        if var in obj.__dict__:
-            del obj.__dict__[var]
+    obj_dict = obj.__dict__
+    for var in _cached_property_names(type(obj)):
+        if var in obj_dict:
+            del obj_dict[var]

--- a/src/new_fave/measurements/vowel_measurement.py
+++ b/src/new_fave/measurements/vowel_measurement.py
@@ -348,10 +348,8 @@ class VowelMeasurement(Sequence, PropertySetter):
         if self._expanded_formants is not None:
             return self._expanded_formants
 
-        self._expanded_formants = np.apply_along_axis(
-            lambda x: idct(x.T, n = 20, orthogonalize=True, norm = "forward"),
-            0,
-            self.cand_param
+        self._expanded_formants = idct(
+            self.cand_param, n=20, orthogonalize=True, norm="forward", axis=0
         )
         return self._expanded_formants    
 

--- a/src/new_fave/measurements/vowel_measurement.py
+++ b/src/new_fave/measurements/vowel_measurement.py
@@ -634,6 +634,15 @@ class VowelMeasurement(Sequence, PropertySetter):
         return pl.DataFrame(point_dict)
     
     @cached_property
+    def _context_literals(self) -> dict[str, pl.Expr]:
+        ctx = self.vm_context
+        row = ctx.row(0, named=True)
+        return {
+            name: pl.lit(row[name], dtype=ctx.schema[name])
+            for name in ctx.columns if name != "id"
+        }
+
+    @cached_property
     def vm_context(
         self
     ) -> pl.DataFrame:   
@@ -694,11 +703,7 @@ class VowelMeasurement(Sequence, PropertySetter):
         intens_param = self.track.intensity_smooth.params
         n = df.shape[0]
         df = df.with_columns(
-            speaker_num = (
-                pl.col("id")
-                .str.extract(r"^(\d+)-")
-                .str.to_integer() + 1
-            ),
+            speaker_num = pl.lit(int(self.id.split("-", 1)[0]) + 1, dtype=pl.Int64),
             f0 = pl.Series(
                 idct(f0_param, n = n, orthogonalize=True, norm = "forward")
             ),
@@ -731,7 +736,7 @@ class VowelMeasurement(Sequence, PropertySetter):
         cols.insert(time_idx+1, "prop_time")
         cols.insert(time_idx+1, "rel_time")
         df = df.select(cols)
-        df = df.join(self.vm_context, on = "id")
+        df = df.with_columns(**self._context_literals)
 
         return df
 
@@ -758,14 +763,10 @@ class VowelMeasurement(Sequence, PropertySetter):
             max_formant = self.winner.maximum_formant,
             f0 = pl.Series(f0),
             intensity = pl.Series(intens),
-            speaker_num = (
-                pl.col("id")
-                .str.extract(r"^(\d+)-")
-                .str.to_integer() + 1
-            )
+            speaker_num = pl.lit(int(self.id.split("-", 1)[0]) + 1, dtype=pl.Int64)
         )
         
-        df = df.join(self.vm_context, on = "id")
+        df = df.with_columns(**self._context_literals)
         
         return df
 
@@ -778,11 +779,7 @@ class VowelMeasurement(Sequence, PropertySetter):
         """
         df = self.point_measure
         df = df.with_columns(
-            speaker_num = (
-                pl.col("id")
-                .str.extract(r"^(\d+)-")
-                .str.to_integer() + 1
-            ),
+            speaker_num = pl.lit(int(self.id.split("-", 1)[0]) + 1, dtype=pl.Int64),
             point_heuristic = pl.lit(self.heuristic.heuristic)
         )
 
@@ -797,7 +794,7 @@ class VowelMeasurement(Sequence, PropertySetter):
                 pl.col("time") + self.interval.start - half
             )
 
-        df = df.join(self.vm_context, on = "id")
+        df = df.with_columns(**self._context_literals)
 
         return(df)
 

--- a/src/new_fave/measurements/vowel_measurement.py
+++ b/src/new_fave/measurements/vowel_measurement.py
@@ -272,9 +272,10 @@ class VowelMeasurement(Sequence, PropertySetter):
         # if self.spectral_rolloff < 7:
         #     joint += self.place_penalty/100
 
-        idx = np.nanargmax(joint)
+        idx = int(np.nanargmax(joint))
 
         self._winner = self.track.candidates[idx]
+        self._winner_idx = idx
     
     @property
     def label(self) -> str:
@@ -324,6 +325,7 @@ class VowelMeasurement(Sequence, PropertySetter):
     @winner.setter
     def winner(self, idx):
         self._winner = self.candidates[idx]
+        self._winner_idx = int(idx)
         self._reset_winners()
         self.vowel_class.vowel_system._reset_winners()
         self.vowel_class._reset_winners()
@@ -339,7 +341,7 @@ class VowelMeasurement(Sequence, PropertySetter):
     
     @property
     def winner_index(self)->int:
-        return self.candidates.index(self.winner)
+        return self._winner_idx
     
     @property
     def expanded_formants(

--- a/src/new_fave/optimize/left_edge.py
+++ b/src/new_fave/optimize/left_edge.py
@@ -27,18 +27,13 @@ def beyond_edge(
     slopes = np.linspace(-1.5, -0.75, num = 10)
     penalty = -0.3
 
-    edge_logprob = np.zeros(len(vowel_measurement))
     vowel_system = vowel_measurement.vowel_class.vowel_system
-    
     intercepts = vowel_system.edge_intercept(slopes)
     xes = vowel_measurement.cand_centroid[0,1,:]
     ys = vowel_measurement.cand_centroid[0,0,:]
-    
-    for i, s in zip(intercepts, slopes):
-        y_max = i + (s * xes)
-        edge_logprob[ys > y_max] += penalty
 
-    y_max = intercepts[-1] + (slopes[-1] * xes)
-
-    edge_logprob[ys > y_max] = -np.inf
+    y_max = intercepts[:, None] + slopes[:, None] * xes[None, :]
+    over = ys[None, :] > y_max
+    edge_logprob = penalty * over.sum(axis=0)
+    edge_logprob[over[-1]] = -np.inf
     return edge_logprob

--- a/src/new_fave/patterns/common_processing.py
+++ b/src/new_fave/patterns/common_processing.py
@@ -84,6 +84,7 @@ def resolve_speaker(
     if isinstance(speakers, (str, Path)):
         speaker_path = Path(speakers)
 
+    speaker_demo = None
     if speaker_path:
         speaker_demo = Speaker(speaker_path, file_name)
         speakers = speaker_demo.df["speaker_num"].to_list()

--- a/src/new_fave/patterns/fave_audio_textgrid.py
+++ b/src/new_fave/patterns/fave_audio_textgrid.py
@@ -153,25 +153,24 @@ def fave_audio_textgrid(
     ]
 
     if len(extra_speakers) > 0:
-        extra_df = (
-            speaker_demo.df
-            .filter(
-                pl.col("speaker_num").is_in(extra_speakers)
+        detail = ""
+        if speaker_demo is not None:
+            extra_df = (
+                speaker_demo.df
+                .filter(
+                    pl.col("speaker_num").is_in(extra_speakers)
+                )
             )
-        )
+            detail = f"\n{extra_df}"
         speakers = [
             sp
             for sp in speakers
             if sp < len(atg)
         ]
         warnings.warn(
-            ( 
-                "Some values of speaker_num were greater than "
-                "the number of TextGrid tiers.\n"
-                f"{extra_df}"
-
-            )
-        )        
+            "Some values of speaker_num were greater than "
+            f"the number of TextGrid tiers.{detail}"
+        )
             
     target_tgs = [tg_names[i] for i in speakers]
     target_candidates = [

--- a/src/new_fave/patterns/fave_corpus.py
+++ b/src/new_fave/patterns/fave_corpus.py
@@ -133,10 +133,9 @@ def fave_corpus(
 
         target_candidates = [
             cand for cand in candidates
-            for fn, num in zip(file_names, speaker_nums)
             if (
-                cand.file_name, 
-                int(re.search("^(\d+)-", cand.id).group(1))+1
+                cand.file_name,
+                int(re.search(r"^(\d+)-", cand.id).group(1))
             ) in target_speakers
         ]
 

--- a/src/new_fave/patterns/fave_subcorpora.py
+++ b/src/new_fave/patterns/fave_subcorpora.py
@@ -151,7 +151,7 @@ def fave_subcorpora(
             cand for cand in candidates
             if (
                 cand.file_name, 
-                int(re.search("^(\d+)-", cand.id).group(1))
+                int(re.search(r"^(\d+)-", cand.id).group(1))
             ) in target_speakers
         ]
 

--- a/src/new_fave/patterns/writers.py
+++ b/src/new_fave/patterns/writers.py
@@ -203,7 +203,7 @@ def check_outputs(
             "log_param", 
             "textgrid"
         ]
-    affixes = copy(which)
+    affixes = list(which)
     for i,a in enumerate(affixes):
         if a == "log_param":
             affixes[i] = "logparam"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,34 +169,6 @@ def test_add_rules():
     tmp.cleanup()
     
 
-def test_which_textgrid_only():
-    tmp = tempfile.TemporaryDirectory()
-    tmp_path = Path(tmp.name)
-
-    audio_path = Path("tests", "test_data", "corpus", "josef-fruehwald_speaker.wav")
-    textgrid_path = Path("tests", "test_data", "corpus", "josef-fruehwald_speaker.TextGrid")
-    ft_config = Path("tests", "test_patterns", "test_ft_config.yml")
-
-    runner = CliRunner()
-
-    result = runner.invoke(
-        fave_extract,
-        [
-            "audio-textgrid",
-            str(audio_path),
-            str(textgrid_path),
-            "--destination", tmp.name,
-            "--ft-config", str(ft_config),
-            "--which", "textgrid"
-        ]
-    )
-
-    assert result.exit_code == 0, result.output
-    tgs = list(tmp_path.glob("*_recoded.TextGrid"))
-    assert len(tgs) > 0
-    tmp.cleanup()
-
-
 def test_which_log_param_only():
     tmp = tempfile.TemporaryDirectory()
     tmp_path = Path(tmp.name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,6 +169,111 @@ def test_add_rules():
     tmp.cleanup()
     
 
+def test_which_textgrid_only():
+    tmp = tempfile.TemporaryDirectory()
+    tmp_path = Path(tmp.name)
+
+    audio_path = Path("tests", "test_data", "corpus", "josef-fruehwald_speaker.wav")
+    textgrid_path = Path("tests", "test_data", "corpus", "josef-fruehwald_speaker.TextGrid")
+    ft_config = Path("tests", "test_patterns", "test_ft_config.yml")
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        fave_extract,
+        [
+            "audio-textgrid",
+            str(audio_path),
+            str(textgrid_path),
+            "--destination", tmp.name,
+            "--ft-config", str(ft_config),
+            "--which", "textgrid"
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    tgs = list(tmp_path.glob("*_recoded.TextGrid"))
+    assert len(tgs) > 0
+    tmp.cleanup()
+
+
+def test_which_log_param_only():
+    tmp = tempfile.TemporaryDirectory()
+    tmp_path = Path(tmp.name)
+
+    audio_path = Path("tests", "test_data", "corpus", "josef-fruehwald_speaker.wav")
+    textgrid_path = Path("tests", "test_data", "corpus", "josef-fruehwald_speaker.TextGrid")
+    ft_config = Path("tests", "test_patterns", "test_ft_config.yml")
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        fave_extract,
+        [
+            "audio-textgrid",
+            str(audio_path),
+            str(textgrid_path),
+            "--destination", tmp.name,
+            "--ft-config", str(ft_config),
+            "--which", "log_param"
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    csvs = list(tmp_path.glob("*_logparam.csv"))
+    assert len(csvs) > 0
+    tmp.cleanup()
+
+
+def test_corpus_mixed_overwrite_alignment():
+    tmp = tempfile.TemporaryDirectory()
+    tmp_path = Path(tmp.name)
+
+    corpus_path = Path("tests", "test_data", "corpus")
+    ft_config = Path("tests", "test_patterns", "test_ft_config.yml")
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        fave_extract,
+        [
+            "corpus",
+            str(corpus_path),
+            "--destination", tmp.name,
+            "--ft-config", str(ft_config),
+            "--speakers", "all"
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    pre_stems = {p.stem for p in tmp_path.glob("KY25A_1*_tracks.csv")}
+    assert len(pre_stems) > 0
+
+    for p in tmp_path.glob("josef-fruehwald_speaker*"):
+        p.unlink()
+
+    result = runner.invoke(
+        fave_extract,
+        [
+            "corpus",
+            str(corpus_path),
+            "--destination", tmp.name,
+            "--ft-config", str(ft_config),
+            "--speakers", "all"
+        ],
+        input='n\n'
+    )
+    assert result.exit_code == 0, result.output
+
+    csvs = list(tmp_path.glob("josef-fruehwald_speaker*_tracks.csv"))
+    assert len(csvs) > 0, (
+        "Output for josef-fruehwald_speaker was not written even though "
+        "the user only declined overwrite for KY25A_1"
+    )
+
+    tmp.cleanup()
+
+
 def test_subcorpora():
     tmp = tempfile.TemporaryDirectory()
     tmp_path = Path(tmp.name)

--- a/tests/test_patterns/test_audio_textgrid.py
+++ b/tests/test_patterns/test_audio_textgrid.py
@@ -45,3 +45,14 @@ def test_audio_textgrid():
 
     assert isinstance(SPEAKERS_spfile.speaker, Speaker)
 
+
+def test_audio_textgrid_speaker_out_of_range():
+    out_of_range = fave_audio_textgrid(
+        audio_path=WAV,
+        textgrid_path=TG,
+        speakers=99,
+        ft_config=Path("tests", "test_patterns", "test_ft_config.yml"),
+    )
+    assert isinstance(out_of_range, SpeakerCollection)
+    assert len(out_of_range) == 0
+

--- a/tests/test_patterns/test_common_processing.py
+++ b/tests/test_patterns/test_common_processing.py
@@ -1,0 +1,19 @@
+from new_fave.patterns.common_processing import resolve_speaker
+
+
+def test_resolve_speaker_int():
+    demo, speakers = resolve_speaker(0)
+    assert demo is None
+    assert speakers == [0]
+
+
+def test_resolve_speaker_all():
+    demo, speakers = resolve_speaker("all")
+    assert demo is None
+    assert speakers == "all"
+
+
+def test_resolve_speaker_list():
+    demo, speakers = resolve_speaker([0, 1])
+    assert demo is None
+    assert speakers == [0, 1]

--- a/tests/test_patterns/test_common_processing.py
+++ b/tests/test_patterns/test_common_processing.py
@@ -1,18 +1,6 @@
 from new_fave.patterns.common_processing import resolve_speaker
 
 
-def test_resolve_speaker_int():
-    demo, speakers = resolve_speaker(0)
-    assert demo is None
-    assert speakers == [0]
-
-
-def test_resolve_speaker_all():
-    demo, speakers = resolve_speaker("all")
-    assert demo is None
-    assert speakers == "all"
-
-
 def test_resolve_speaker_list():
     demo, speakers = resolve_speaker([0, 1])
     assert demo is None

--- a/tests/test_patterns/test_corpus.py
+++ b/tests/test_patterns/test_corpus.py
@@ -29,3 +29,19 @@ def test_fave_corpus():
 
     assert isinstance(SPEAKERS_spfile.speaker, Speaker)
 
+
+def test_fave_corpus_demo_keys_and_unique():
+    expected = {
+        ("KY25A_1", "KY25A"),
+        ("KY25A_1", "IVR"),
+        ("josef-fruehwald_speaker", "group_0"),
+    }
+    assert set(SPEAKERS_spfile.keys()) == expected
+
+    for key, vcc in SPEAKERS_spfile.items():
+        ids = [vm.id for vc in vcc.values() for vm in vc]
+        assert len(ids) == len(set(ids)), (
+            f"duplicate candidate ids under {key}: "
+            f"{len(ids) - len(set(ids))} duplicates"
+        )
+


### PR DESCRIPTION
## Summary

Closes #75. Addresses #8.

This PR fixes a handful of CLI and Python API edge cases: non-default `--which` crashes, skipped outputs after declined overwrites, `list[int]` speaker handling, speaker-demographics filtering in `fave_corpus`, and out-of-range speaker warnings without demographics. It also fixes some small help text, documentation, and regex issues.

The performance work targets the `to_*_df` pipeline and the optimize loop. End-to-end runtime on the test corpus dropped from ~15.2 s to ~5.94 s.

## Bug fixes

1. **fix check_outputs tuple TypeError for non-default --which (#75)**. `affixes = copy(which)` kept the click `multiple=True` tuple immutable, so assigning `affixes[i] = "logparam"` raised `TypeError`. The fix converts it to a list. Regression test: `test_which_log_param_only` in `tests/test_cli.py`.

2. **fix which-list misalignment when overwrite declined mid-corpus**. `corpus` and `subcorpora` filtered skipped files out of `audio_to_process` but did not apply the same filter to the parallel `result_which` list. That misaligned later `zip(corpus, result_which)` pairs and could silently skip the next file's output. The fix filters `result_which` the same way as `audio_to_process`. Regression test: `test_corpus_mixed_overwrite_alignment` in `tests/test_cli.py`.

3. **fix resolve_speaker UnboundLocalError on list[int] input**. The function accepted `list[int]`, but `speaker_demo` was only assigned inside the `if speaker_path:` branch. Passing a list from the Python API skipped that branch and crashed on return. The fix initializes `speaker_demo = None` before the conditional. Regression test: `test_resolve_speaker_list` in `tests/test_patterns/test_common_processing.py`.

4. **fix fave_corpus speaker-demographics filtering**. `fave_corpus` had an unused nested loop that duplicated candidates and an off-by-one speaker index that selected the wrong speakers. The fix makes the lookup match `fave_subcorpora`: no unused inner loop and no extra `+1`. With the `speaker3.yml` fixture, baseline returned 1 of 3 speaker keys and 48 vowel measurements, including 32 duplicate ids; after the fix it returns 3 keys with 338 unique measurements matching the corpus. Regression test: `test_fave_corpus_demo_keys_and_unique` in `tests/test_patterns/test_corpus.py`.

5. **guard speaker_demo access when extra speakers are passed without demographics**. `fave_audio_textgrid(... speakers=99)` crashed when no demographics file was provided because the warning path tried to read `speaker_demo.df` even though `speaker_demo` was `None`. The fix checks whether `speaker_demo` exists before reading from it and still emits the warning. Regression test: `test_audio_textgrid_speaker_out_of_range` in `tests/test_patterns/test_audio_textgrid.py`.

6. **fix small string, help, and regex issues**. The `--vowel-place` help text typo is fixed, the `python_usage.qmd` Audio + TextGrid example now uses matching stems, and the non-raw `"\d"` regexes no longer trigger Python 3.13 `SyntaxWarning`s.

## Performance

End-to-end timing of `fave_audio_textgrid` plus `write_data` on `tests/test_data/corpus/josef-fruehwald_speaker.{wav,TextGrid}` with 273 vowel measurements, median of 3 runs:

| state | extract | write | total |
|---|---:|---:|---:|
| baseline | ~10.3 s | ~5.0 s | ~15.2 s |
| + 24a1ba9 inline vm_context literals | ~5.8 s | ~3.7 s | ~9.5 s |
| + 2893676 vectorize expanded_formants | ~4.45 s | ~2.67 s | ~7.22 s |
| + 3376e6f direct chdtr piecewise | ~3.49 s | ~3.06 s | ~6.40 s |
| + 5e66ab0, ab49608 cache + vectorize | ~3.25 s | ~2.77 s | ~6.04 s |
| + 4c11d34 cached winner_index | ~3.27 s | ~2.67 s | ~5.94 s |

The main changes are:

- **Inline `vm_context` as scalar literals**. The `to_*_df` methods no longer join a one-row context dataframe onto every vowel measurement. They build cached literal columns once and add them with `with_columns`, which removes thousands of small Polars operations. Addresses #8.

- **Vectorize `expanded_formants`**. The code now calls `scipy.fft.idct` across the full array with `axis=` instead of looping with `np.apply_along_axis`.

- **Use direct scipy.special calls for chi-square log survival**. The code replaces repeated `scipy.stats.chi2.logsf` dispatch with the equivalent `scipy.special` calculation while preserving output.

- **Cache cached_property names per class**. `clear_cached_properties` no longer repeatedly walks the MRO and class dictionaries on every call.

- **Vectorize `beyond_edge`**. The slope-intercept loop is replaced with a broadcasted ndarray operation.

- **Cache `winner_index`**. The selected candidate index is stored when the winner is initialized or changed, avoiding repeated `list.index` scans.

## Test maintenance

- Removed overlapping `resolve_speaker` and `--which` tests while keeping regression coverage for the actual failure paths.

## Related issues

- Closes #75.
- Directly addresses #8.
- Relates to #22 by fixing the remaining `python_usage.qmd` typo.

## Verification

- `uv run pytest`: 53 passed, 3 pre-existing skips.
- Output CSV equivalence: `diff -q` clean on tracks, param, logparam, and points before vs after the full set of changes.
- Python 3.13 SyntaxWarnings for `"\d"` in `fave_corpus.py` and `fave_subcorpora.py` are gone.